### PR TITLE
feat: add board coordinates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 local.config.js
 .env
+
+node_modules

--- a/app.js
+++ b/app.js
@@ -90,6 +90,20 @@ function render() {
       cell.dataset.row = r;
       cell.dataset.col = c;
 
+      // coordinate labels
+      if (c === 0) {
+        const lbl = document.createElement('div');
+        lbl.className = 'row-label';
+        lbl.textContent = 10 - r;
+        cell.appendChild(lbl);
+      }
+      if (r === 9) {
+        const lbl = document.createElement('div');
+        lbl.className = 'col-label';
+        lbl.textContent = String.fromCharCode(65 + c);
+        cell.appendChild(lbl);
+      }
+
       const p = board[r][c];
       if (p) {
         const el = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -39,6 +39,9 @@ button:hover { background:#fafafa; }
   grid-template-columns: repeat(9, 1fr);
   grid-template-rows: repeat(10, 1fr);
   position: relative;
+  margin-left: 1.2em;
+  margin-bottom: 1.2em;
+  overflow: visible;
 }
 
 /* SVG overlay for authentic Xiangqi board lines */
@@ -65,6 +68,25 @@ button:hover { background:#fafafa; }
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.row-label,
+.col-label {
+  position: absolute;
+  font-size: 0.6em;
+  color: #777;
+}
+
+.row-label {
+  left: -1.2em;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.col-label {
+  bottom: -1.2em;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 /* River decoration */


### PR DESCRIPTION
## Summary
- show row and column coordinates on the Xiangqi board
- style labels and board margins for coordinates
- ignore `node_modules` in git

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b779684e0883289aec70fc6887b31b