### PR TITLE
feat: add board coordinates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 local.config.js
 .env
+
+node_modules

--- a/app.js
+++ b/app.js
@@ -90,6 +90,20 @@ function render() {
       cell.dataset.row = r;
       cell.dataset.col = c;
 
+      // coordinate labels
+      if (c === 0) {
+        const lbl = document.createElement('div');
+        lbl.className = 'row-label';
+        lbl.textContent = 10 - r;
+        cell.appendChild(lbl);
+      }
+      if (r === 9) {
+        const lbl = document.createElement('div');
+        lbl.className = 'col-label';
+        lbl.textContent = String.fromCharCode(65 + c);
+        cell.appendChild(lbl);
+      }
+
       const p = board[r][c];
       if (p) {
         const el = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -39,6 +39,9 @@ button:hover { background:#fafafa; }
   grid-template-columns: repeat(9, 1fr);
   grid-template-rows: repeat(10, 1fr);
   position: relative;
+  margin-left: 1.2em;
+  margin-bottom: 1.2em;
+  overflow: visible;
 }
 
 /* SVG overlay for authentic Xiangqi board lines */
@@ -62,9 +65,27 @@ button:hover { background:#fafafa; }
 /* Grid lines */
 .cell {
   position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+}
+
+.row-label,
+.col-label {
+  position: absolute;
+  font-size: 0.6em;
+  color: #777;
+}
+
+
+.row-label {
+  left: -1.2em;
+  top: 0;
+  transform: translateY(-50%);
+}
+
+
+.col-label {
+  bottom: -1.2em;
+  left: 0;
+  transform: translateX(-50%);
 }
 
 /* River decoration */
@@ -82,7 +103,10 @@ button:hover { background:#fafafa; }
   font-weight: 700;
   user-select: none;
   box-shadow: 0 2px 0 rgba(0,0,0,.06);
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translate(-50%, -50%);
   z-index: 2; /* above board lines */
 }
 .piece.red { color: var(--red); border-color: #dba49b; }
@@ -90,8 +114,24 @@ button:hover { background:#fafafa; }
 .piece.focus { outline: 3px solid #88e; }
 
 /* Move highlights */
-.hint { position:absolute; inset: 0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index: 2; }
-.dot { width: 28%; aspect-ratio:1/1; border-radius:50%; background: var(--move); border: 1px solid #8ad39b; opacity:.95; }
+.hint {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+}
+.dot {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 28%;
+  aspect-ratio:1/1;
+  border-radius:50%;
+  background: var(--move);
+  border: 1px solid #8ad39b;
+  opacity:.95;
+  transform: translate(-50%, -50%);
+}
 .dot.capture { background: var(--capture); border-color: #e47b7b; }
 
 .legend { margin-top: 10px; color: #666; display:flex; gap: 14px; align-items:center; }


### PR DESCRIPTION
## Summary
- show row and column coordinates on the Xiangqi board
- style labels and board margins for coordinates
- place pieces and move hints on grid intersections
- ignore `node_modules` in git

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b779684e0883289aec70fc6887b31b