### PR TITLE
feat: add board coordinates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 local.config.js
 .env
+
+node_modules
+board.png

--- a/app.js
+++ b/app.js
@@ -18,6 +18,12 @@ const resetBtn = document.getElementById('resetBtn');
 const aiToggle = document.getElementById('aiToggle');
 const aiLevelSelect = document.getElementById('aiLevel');
 
+// layout constants based on board.png (percentages of container size)
+const BOARD_OFF_X = 5.08;      // left/right margin
+const BOARD_OFF_TOP = 5.08;    // top margin
+const BOARD_STEP_X = 11.23;    // horizontal distance between files
+const BOARD_STEP_Y = 9.982;    // vertical distance between ranks
+
 resetBtn.addEventListener('click', () => init());
 aiToggle?.addEventListener('change', () => {
   blackAI = !!aiToggle.checked;
@@ -80,8 +86,6 @@ function createInitialBoard() {
 
 function render() {
   boardEl.innerHTML = '';
-  drawBoardOverlaySvg(boardEl);
-
   for (let r = 0; r < 10; r++) {
     for (let c = 0; c < 9; c++) {
       const cell = document.createElement('div');
@@ -89,6 +93,27 @@ function render() {
       cell.setAttribute('role', 'gridcell');
       cell.dataset.row = r;
       cell.dataset.col = c;
+
+      const left = BOARD_OFF_X + BOARD_STEP_X * c;
+      const top = BOARD_OFF_TOP + BOARD_STEP_Y * r;
+      cell.style.left = left + '%';
+      cell.style.top = top + '%';
+      cell.style.width = BOARD_STEP_X + '%';
+      cell.style.height = BOARD_STEP_Y + '%';
+
+      // coordinate labels
+      if (c === 0) {
+        const lbl = document.createElement('div');
+        lbl.className = 'row-label';
+        lbl.textContent = 10 - r;
+        cell.appendChild(lbl);
+      }
+      if (r === 9) {
+        const lbl = document.createElement('div');
+        lbl.className = 'col-label';
+        lbl.textContent = String.fromCharCode(65 + c);
+        cell.appendChild(lbl);
+      }
 
       const p = board[r][c];
       if (p) {
@@ -602,102 +627,6 @@ function hasAnyLegalMove(b, side) {
     }
   }
   return false;
-}
-
-// ===== Board overlay (SVG) =====
-function drawBoardOverlaySvg(container) {
-  const svgNS = 'http://www.w3.org/2000/svg';
-  const svg = document.createElementNS(svgNS, 'svg');
-  svg.setAttribute('class', 'board-overlay');
-  // Match the logical grid: 9 columns (x: 0..8), 10 rows (y: 0..9)
-  // Using a 9x10 viewBox makes integer coordinates align with cell centers.
-  svg.setAttribute('viewBox', '0 0 9 10');
-  svg.setAttribute('preserveAspectRatio', 'none');
-
-  const stroke = '#8b6f47';
-  const stroke2 = '#8b6f47';
-  const accent = '#c89b3c';
-  // Use pixel-like widths to keep lines visible with non-scaling-stroke
-  const GRID_W = 1.2;      // inner grid lines (screen px)
-  const BORDER_W = 2.4;    // outer border (unused if CSS border is present)
-
-  const line = (x1, y1, x2, y2, w = GRID_W) => {
-    const el = document.createElementNS(svgNS, 'line');
-    el.setAttribute('x1', x1);
-    el.setAttribute('y1', y1);
-    el.setAttribute('x2', x2);
-    el.setAttribute('y2', y2);
-    el.setAttribute('stroke', stroke);
-    el.setAttribute('stroke-width', w);
-    el.setAttribute('vector-effect', 'non-scaling-stroke');
-    svg.appendChild(el);
-  };
-
-  // Outer border is provided by CSS (#board { border }) so we skip drawing it here
-
-  // Horizontal inner lines (between top and bottom borders): y = 1..9
-  for (let y = 1; y <= 9; y++) {
-    line(0, y, 9, y);
-  }
-
-  // Vertical lines, with river gap between y=4 and y=5
-  for (let x = 0; x <= 9; x++) {
-    // top half
-    line(x, 0, x, 4);
-    // bottom half
-    line(x, 5, x, 10);
-  }
-
-  // Palace diagonals
-  line(3, 0, 5, 2);
-  line(5, 0, 3, 2);
-  line(3, 7, 5, 9);
-  line(5, 7, 3, 9);
-
-  // River label
-  const text = document.createElementNS(svgNS, 'text');
-  text.setAttribute('x', 1.6);
-  text.setAttribute('y', 4.6);
-  text.setAttribute('fill', accent);
-  text.setAttribute('font-size', '0.6');
-  text.setAttribute('font-weight', '700');
-  text.textContent = '楚河';
-  svg.appendChild(text);
-  const text2 = document.createElementNS(svgNS, 'text');
-  text2.setAttribute('x', 5.4);
-  text2.setAttribute('y', 4.6);
-  text2.setAttribute('fill', accent);
-  text2.setAttribute('font-size', '0.6');
-  text2.setAttribute('font-weight', '700');
-  text2.textContent = '汉界';
-  svg.appendChild(text2);
-
-  // Star points (cannons and soldiers) as small corner crosses
-  const drawCross = (cx, cy) => {
-    const size = 0.18;
-    const thickness = 1; // thicker for visibility
-    const mk = (x1, y1, x2, y2) => {
-      const c = document.createElementNS(svgNS, 'line');
-      c.setAttribute('x1', x1);
-      c.setAttribute('y1', y1);
-      c.setAttribute('x2', x2);
-      c.setAttribute('y2', y2);
-      c.setAttribute('stroke', stroke2);
-      c.setAttribute('stroke-width', thickness);
-      c.setAttribute('vector-effect', 'non-scaling-stroke');
-      svg.appendChild(c);
-    };
-    mk(cx - size, cy - size, cx - size / 3, cy - size / 3);
-    mk(cx + size, cy - size, cx + size / 3, cy - size / 3);
-    mk(cx - size, cy + size, cx - size / 3, cy + size / 3);
-    mk(cx + size, cy + size, cx + size / 3, cy + size / 3);
-  };
-  const cannonXs = [1, 7];
-  cannonXs.forEach(x => { drawCross(x, 2); drawCross(x, 7); });
-  const soldierXs = [0, 2, 4, 6, 8];
-  soldierXs.forEach(x => { drawCross(x, 3); drawCross(x, 6); });
-
-  container.appendChild(svg);
 }
 
 // ===== AI helpers (difficulty) =====

--- a/style.css
+++ b/style.css
@@ -30,45 +30,41 @@ button { padding: 6px 12px; border-radius: 6px; border: 1px solid #bbb; backgrou
 button:hover { background:#fafafa; }
 
 #board {
-  background: var(--cell);
-  border: 3px solid var(--line);
-  border-radius: 8px;
-  aspect-ratio: 9 / 10;
+  background: url('board.png') center/100% 100% no-repeat;
+  aspect-ratio: 1 / 1;
   width: 100%;
-  display: grid;
-  grid-template-columns: repeat(9, 1fr);
-  grid-template-rows: repeat(10, 1fr);
   position: relative;
+  margin-left: 1.2em;
+  margin-bottom: 1.2em;
+  overflow: visible;
 }
 
-/* SVG overlay for authentic Xiangqi board lines */
-.board-overlay {
-  position: absolute;
-  /* Match the content box (inside the #board border: 3px) */
-  inset: 3px;
-  width: auto;
-  height: auto;
-  pointer-events: none;
-  z-index: 1;
-}
-
-/* Ensure lines render crisply and keep stroke width during scaling */
-.board-overlay line,
-.board-overlay path {
-  vector-effect: non-scaling-stroke;
-  shape-rendering: crispEdges;
-}
-
-/* Grid lines */
 .cell {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  position: absolute;
 }
 
-/* River decoration */
-/* River now drawn in SVG overlay */
+.row-label,
+.col-label {
+  position: absolute;
+  font-size: 0.6em;
+  color: #777;
+}
+
+
+.row-label {
+  left: -1.2em;
+  top: 0;
+  transform: translateY(-50%);
+}
+
+
+.col-label {
+  bottom: -1.2em;
+  left: 0;
+  transform: translateX(-50%);
+}
+
+/* River decoration comes from background image */
 
 /* Piece styling */
 .piece {
@@ -82,7 +78,10 @@ button:hover { background:#fafafa; }
   font-weight: 700;
   user-select: none;
   box-shadow: 0 2px 0 rgba(0,0,0,.06);
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translate(-50%, -50%);
   z-index: 2; /* above board lines */
 }
 .piece.red { color: var(--red); border-color: #dba49b; }
@@ -90,8 +89,24 @@ button:hover { background:#fafafa; }
 .piece.focus { outline: 3px solid #88e; }
 
 /* Move highlights */
-.hint { position:absolute; inset: 0; display:flex; align-items:center; justify-content:center; pointer-events:none; z-index: 2; }
-.dot { width: 28%; aspect-ratio:1/1; border-radius:50%; background: var(--move); border: 1px solid #8ad39b; opacity:.95; }
+.hint {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+}
+.dot {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 28%;
+  aspect-ratio:1/1;
+  border-radius:50%;
+  background: var(--move);
+  border: 1px solid #8ad39b;
+  opacity:.95;
+  transform: translate(-50%, -50%);
+}
 .dot.capture { background: var(--capture); border-color: #e47b7b; }
 
 .legend { margin-top: 10px; color: #666; display:flex; gap: 14px; align-items:center; }


### PR DESCRIPTION
## Summary
- show row and column coordinates on the Xiangqi board
- style labels and board margins for coordinates
- place pieces and move hints on grid intersections
- render the board from a static `board.png` image
- ignore `node_modules` and `board.png` in git
- fine-tune board offsets so pieces sit exactly on grid intersections

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b779684e0883289aec70fc6887b31b