### PR TITLE
fix: correct lib imports in API routes

### DIFF
--- a/api/login.js
+++ b/api/login.js
@@ -1,8 +1,8 @@
 // api/login.js
 import bcrypt from "bcryptjs";
-import redis from "./_lib/redis.js";
-import { createSession, setSessionCookie } from "./_lib/session.js";
-import { rateLimit } from "./_lib/ratelimit.js";
+import redis from "./lib/redis.js";
+import { createSession, setSessionCookie } from "./lib/session.js";
+import { rateLimit } from "./lib/ratelimit.js";
 
 export default async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });

--- a/api/logout.js
+++ b/api/logout.js
@@ -1,5 +1,5 @@
 // api/logout.js
-import { destroySession, clearSessionCookie } from "./_lib/session.js";
+import { destroySession, clearSessionCookie } from "./lib/session.js";
 
 export default async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });

--- a/api/me.js
+++ b/api/me.js
@@ -1,6 +1,6 @@
 // api/me.js
-import redis from "./_lib/redis.js";
-import { getSession } from "./_lib/session.js";
+import redis from "./lib/redis.js";
+import { getSession } from "./lib/session.js";
 
 export default async function handler(req, res) {
   const sess = await getSession(req);

--- a/api/signup.js
+++ b/api/signup.js
@@ -1,9 +1,9 @@
 // api/signup.js
 import bcrypt from "bcryptjs";
 import { nanoid } from "nanoid";
-import redis from "./_lib/redis.js";
-import { createSession, setSessionCookie } from "./_lib/session.js";
-import { rateLimit } from "./_lib/ratelimit.js";
+import redis from "./lib/redis.js";
+import { createSession, setSessionCookie } from "./lib/session.js";
+import { rateLimit } from "./lib/ratelimit.js";
 
 export default async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });


### PR DESCRIPTION
## Summary
- fix API route imports to use `./lib/*`

## Testing
- `UPSTASH_REDIS_REST_URL=http://example.com UPSTASH_REDIS_REST_TOKEN=token node --input-type=module -e "await Promise.all(['./api/login.js','./api/logout.js','./api/me.js','./api/signup.js'].map(f => import(f))); console.log('loaded');"`

------
https://chatgpt.com/codex/tasks/task_e_68bd9e23a7988328afcab1028e09ca4a