### PR TITLE
chore: add node-fetch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@upstash/redis": "^1.28.4",
     "bcryptjs": "^2.4.3",
     "cookie": "^0.6.0",
-    "nanoid": "^5.0.7"
+    "nanoid": "^5.0.7",
+    "node-fetch": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add node-fetch to dependencies for environments without native fetch

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-fetch)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bd9e2579088328ad1692a0b5e90bb8