### PR TITLE
Track last login time for users

### DIFF
--- a/api/login.js
+++ b/api/login.js
@@ -26,6 +26,8 @@ export default async function handler(req, res) {
   const ok = await bcrypt.compare(password, user.password_hash);
   if (!ok) return res.status(401).json({ error: "Invalid credentials" });
 
+  await redis.hset(`user:id:${userId}`, { last_login_at: Date.now().toString() });
+
   const sid = await createSession(userId, { ua: req.headers["user-agent"] || "", ip });
   setSessionCookie(res, sid);
   res.status(200).json({ userId, username: user.username });

--- a/api/me.js
+++ b/api/me.js
@@ -10,6 +10,11 @@ export default async function handler(req, res) {
   if (!user?.id) return res.status(200).json({ user: null });
 
   res.status(200).json({
-    user: { id: user.id, username: user.username, created_at: Number(user.created_at) || null },
+    user: {
+      id: user.id,
+      username: user.username,
+      created_at: Number(user.created_at) || null,
+      last_login_at: Number(user.last_login_at) || null,
+    },
   });
 }

--- a/api/signup.js
+++ b/api/signup.js
@@ -39,6 +39,7 @@ export default async function handler(req, res) {
       username: uname,
       password_hash: pwdHash,
       created_at: Date.now().toString(),
+      last_login_at: Date.now().toString(),
     });
   } catch (e) {
     // 回滚索引


### PR DESCRIPTION
## Summary
- Record last login timestamp when users sign up or log in
- Expose `last_login_at` in the `/api/me` response

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:redis` *(fails: Missing UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68bda9861aec832897cbc6d818ea5614