### PR TITLE
Add signup hint to login page

### DIFF
--- a/login.html
+++ b/login.html
@@ -15,6 +15,7 @@
     .ghost{background:#1f2937;color:#e2e8f0}
     .row{display:flex;gap:12px}
     .msg{min-height:20px;margin-top:10px;color:#94a3b8}
+    .hint{text-align:center;font-size:14px;color:#94a3b8;margin-top:8px}
   </style>
 </head>
 <body>
@@ -26,6 +27,7 @@
       <button class="primary" id="btnSignup">注册并登录</button>
       <button class="ghost" id="btnLogin">登录</button>
     </div>
+    <div class="hint">首次使用请点“注册并登录”</div>
     <div class="msg" id="msg"></div>
   </div>
   <script src="/auth.js"></script>


### PR DESCRIPTION
## Summary
- Clarify login page with note directing first-time users to the "注册并登录" option

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:redis` *(fails: Missing UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68bda986a6288328b8c5c38e95887898