### PR TITLE
fix: handle parsed bodies for auth

### DIFF
--- a/api/login.js
+++ b/api/login.js
@@ -12,7 +12,9 @@ export default async function handler(req, res) {
   if (!allowed) return res.status(429).json({ error: "Too many attempts, try later." });
 
   let body = {};
-  try { body = JSON.parse(req.body || "{}"); } catch {}
+  try {
+    body = typeof req.body === "string" ? JSON.parse(req.body || "{}") : (req.body || {});
+  } catch {}
   const { username, password } = body;
   if (!username || !password) return res.status(400).json({ error: "Missing username or password" });
 

--- a/api/signup.js
+++ b/api/signup.js
@@ -13,7 +13,9 @@ export default async function handler(req, res) {
   if (!allowed) return res.status(429).json({ error: "Too many attempts, try later." });
 
   let body = {};
-  try { body = JSON.parse(req.body || "{}"); } catch {}
+  try {
+    body = typeof req.body === "string" ? JSON.parse(req.body || "{}") : (req.body || {});
+  } catch {}
   const { username, password } = body;
   if (!username || !password) return res.status(400).json({ error: "Missing username or password" });
 


### PR DESCRIPTION
## Summary
- support already-parsed request bodies in `/api/login`
- support already-parsed request bodies in `/api/signup`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run test:redis` (fails: Missing UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN)


------
https://chatgpt.com/codex/tasks/task_e_68be700661d4832892cbd5599eb090ca