### PR TITLE
fix: handle parsed auth bodies and allow cancelling matchmaking

### DIFF
--- a/api/login.js
+++ b/api/login.js
@@ -12,7 +12,9 @@ export default async function handler(req, res) {
   if (!allowed) return res.status(429).json({ error: "Too many attempts, try later." });
 
   let body = {};
-  try { body = JSON.parse(req.body || "{}"); } catch {}
+  try {
+    body = typeof req.body === "string" ? JSON.parse(req.body || "{}") : (req.body || {});
+  } catch {}
   const { username, password } = body;
   if (!username || !password) return res.status(400).json({ error: "Missing username or password" });
 

--- a/api/signup.js
+++ b/api/signup.js
@@ -13,7 +13,9 @@ export default async function handler(req, res) {
   if (!allowed) return res.status(429).json({ error: "Too many attempts, try later." });
 
   let body = {};
-  try { body = JSON.parse(req.body || "{}"); } catch {}
+  try {
+    body = typeof req.body === "string" ? JSON.parse(req.body || "{}") : (req.body || {});
+  } catch {}
   const { username, password } = body;
   if (!username || !password) return res.status(400).json({ error: "Missing username or password" });
 

--- a/js/matchmaking.js
+++ b/js/matchmaking.js
@@ -6,6 +6,7 @@ export async function startMatchmaking(onMatched) {
   await window.supabase.rpc('enter_queue');           // 入队
   startHeartbeat('matchmaking', true);                // 心跳标注在匹配页
 
+  __mm = 0; // 标记轮询尚未停止
   const poll = async () => {
     try {
       const { data, error } = await window.supabase.rpc('try_match_pair');
@@ -13,17 +14,19 @@ export async function startMatchmaking(onMatched) {
         const id = data.match_id;
         startHeartbeat('room:' + id, false);          // 进入房间
         if (typeof onMatched === 'function') onMatched(id);
-      } else {
+      } else if (__mm !== null) {
         __mm = setTimeout(poll, 1500);
       }
     } catch {
-      __mm = setTimeout(poll, 2000);
+      if (__mm !== null) {
+        __mm = setTimeout(poll, 2000);
+      }
     }
   };
   poll();
 }
 export async function stopMatchmaking() {
-  if (__mm) { clearTimeout(__mm); __mm = null; }
+  if (__mm !== null) { clearTimeout(__mm); __mm = null; }
   await window.supabase.rpc('leave_queue');
   startHeartbeat('lobby', false);
 }

--- a/mode.html
+++ b/mode.html
@@ -31,7 +31,7 @@
   <!-- 大厅逻辑 -->
   <script type="module">
     import { startHeartbeat } from '/js/heartbeat.js';
-    import { startMatchmaking, stopMatchmaking } from '/js/online-game.js';
+    import { startMatchmaking, stopMatchmaking } from '/js/matchmaking.js';
     import '/js/online-count.js'; // 自动更新 #onlineCount
 
     (async () => {


### PR DESCRIPTION
## Summary
- support already-parsed request bodies in `/api/login`
- support already-parsed request bodies in `/api/signup`
- ensure matchmaking polling stops after cancellation and import correct module

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run test:redis` (fails: Missing UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN)


------
https://chatgpt.com/codex/tasks/task_e_68be700661d4832892cbd5599eb090ca