### PR TITLE
Handle animation cleanup reliably

### DIFF
--- a/js/ui-view.js
+++ b/js/ui-view.js
@@ -218,15 +218,22 @@ function doAnimatedMove(from, to, done){
   clone.style.transition= 'left 220ms ease, top 220ms ease';
   boardEl.appendChild(clone);
 
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    boardEl.removeChild(clone);
+    animating = false;
+    done();
+  };
+  clone.addEventListener('transitionend', cleanup, { once:true });
+  clone.addEventListener('transitioncancel', cleanup, { once:true });
+  setTimeout(cleanup, 300);
+
   requestAnimationFrame(() => {
     clone.style.left = (b.left - boardRect.left + b.width/2) + 'px';
     clone.style.top  = (b.top  - boardRect.top  + b.height/2) + 'px';
   });
-  clone.addEventListener('transitionend', () => {
-    boardEl.removeChild(clone);
-    animating=false;
-    done();
-  }, { once:true });
 }
 
 // ========== AI 回合 ==========


### PR DESCRIPTION
## Summary
- Ensure animated move cleanup removes clones and clears animating state
- Listen for transitionend and transitioncancel, with a timeout fallback for no animations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:redis` *(fails: Missing UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN)*


------
https://chatgpt.com/codex/tasks/task_e_68c2282280ec832898d020f54d1fb6a9