### PR TITLE
fix: ensure online game recognizes logged-in user

### DIFF
--- a/js/online-game.js
+++ b/js/online-game.js
@@ -6,7 +6,7 @@ import { startMovePolling, pushMove, stopMovePolling } from '/js/room-sync.js';
 // 在 ui-view.js 里，会 dispatch 一个 'local-move' 事件（见下面补丁）
 // 这里接住并推进 DB；同时轮询 DB 应用对方走子。
 export async function startOnlineGame(matchId) {
-  const { data: { user } } = await window.supabase.auth.getUser();
+  const { user } = await Auth.me();
   if (!user) { alert('请先登录'); return; }
 
   // 读当前最大 ply，作为下一步的编号


### PR DESCRIPTION
## Summary
- Use existing `Auth.me` to check login status before starting an online game

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:redis` *(fails: Missing UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68c2279c1650832896ba7b6052807b96